### PR TITLE
chore: Version bumped to 0.4.0

### DIFF
--- a/AlfredApiWrapper/AlfredApiWrapper.csproj
+++ b/AlfredApiWrapper/AlfredApiWrapper.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <PackageId>TagShelf.Alfred.ApiWrapper</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>Raúl Roa (raul@tagshelf.com)</Authors>
     <Company>Tagshelf</Company>
     <Description>A comprehensive .NET library designed to facilitate seamless interactions with the Alfred API.</Description>


### PR DESCRIPTION
This pull request includes a new `priority` field in the Upload Request DTO, bringing the SDK in line with the full capabilities of the API.

**Detailed Changes:**
Added Priority Support for Upload Requests
The underlying API supports job prioritization with accepted values: "low", "normal" (default), and "high". Until now, the SDK didn’t expose this option, limiting control over request handling.

**This update introduces:**

A Priority enum with values: `Low`, `Normal`, and `High`

A new optional Priority property in the UploadRequest DTO

SDK users can now specify job priority directly when creating upload requests, allowing better control over queue behavior and resource allocation.

Version Bumped to `0.4.0`
This minor version bump reflects the new functionality and expanded support in the upload flow.